### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master # Мы берем мастер ветку
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master # Мы используем готовый экшн для сборки докер образа
+        uses: elgohr/Publish-Docker-Github-Action@v5 # Мы используем готовый экшн для сборки докер образа
         with: # Ниже указаны параметры для экшна
           registry: docker.pkg.github.com
           name: docker.pkg.github.com/popenkov/docker-ci-cd/docker-ci-cd


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore